### PR TITLE
fix(FEC-8838): eventType:7 is missing when video finished playing

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -1039,7 +1039,6 @@ class Youtube extends FakeEventTarget implements IEngine {
 
   _onBuffering() {
     this._stopPlayingWatchDog();
-    this.dispatchEvent(new FakeEvent(EventType.TIME_UPDATE));
     this.dispatchEvent(new FakeEvent(EventType.WAITING));
   }
 
@@ -1047,13 +1046,13 @@ class Youtube extends FakeEventTarget implements IEngine {
     if (this._isSeeking) {
       this._isSeeking = false;
     }
-    this.dispatchEvent(new FakeEvent(EventType.PAUSE));
     this._stopPlayingWatchDog();
+    this.dispatchEvent(new FakeEvent(EventType.PAUSE));
   }
 
   _onEnded() {
-    this.dispatchEvent(new FakeEvent(EventType.PAUSE));
     this._stopPlayingWatchDog();
+    this.dispatchEvent(new FakeEvent(EventType.PAUSE));
     this.dispatchEvent(new FakeEvent(EventType.ENDED));
   }
 
@@ -1067,6 +1066,7 @@ class Youtube extends FakeEventTarget implements IEngine {
   }
 
   _stopPlayingWatchDog() {
+    this.dispatchEvent(new FakeEvent(EventType.TIME_UPDATE));
     clearInterval(this._playingIntervalId);
     this._playingIntervalId = null;
   }


### PR DESCRIPTION
### Description of the Changes

make sure to fire time update event before stopping the play watcher to flush any pending tasks.
It seems that this is what happening in native html5 video, so need to mimic this here as well.

### CheckLists

- [x] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
