### PR TITLE
fix(FEC-8851): reinitialize player while playing a YouTube entry throws an error

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -487,7 +487,7 @@ class Youtube extends FakeEventTarget implements IEngine {
    * @public
    */
   get duration(): number {
-    return this._api ? this._api.getDuration() : NaN;
+    return this._api && this._api.getDuration ? this._api.getDuration() : NaN;
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

seekbar component might try to call the player before media is loaded.
In youtube API this causes the `getDuration` to not exist on the API, so need to make sure it is there before calling it

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
