### PR TITLE
fix(FEC-9275): youtube entry failed to play on IE11

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -55,7 +55,7 @@ class Youtube extends FakeEventTarget implements IEngine {
 
   _source: PKMediaSourceObject;
 
-  _api: Object;
+  _api: any;
 
   _sdkLoaded: Promise<*>;
 

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -891,6 +891,9 @@ class Youtube extends FakeEventTarget implements IEngine {
   _init(source: PKMediaSourceObject, config: Object): void {
     this._source = source;
     this._config = config;
+    this._api = null;
+    this._videoLoaded = null;
+    this._playingIntervalId = null;
     const dispatchError = e => {
       const error = new Error(Error.Severity.CRITICAL, Error.Category.PLAYER, Error.Code.LOAD_FAILED, e);
       this.dispatchEvent(new FakeEvent(EventType.ERROR, error));

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -498,8 +498,10 @@ class Youtube extends FakeEventTarget implements IEngine {
   }
 
   _stopSeekTargetWatchDog() {
-    clearInterval(this._seekTargetIntervalId);
-    this._seekTargetIntervalId = null;
+    if(this._seekTargetIntervalId) {
+      clearInterval(this._seekTargetIntervalId);
+      this._seekTargetIntervalId = null;
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

IE11 with proxy - should init all objects before proxy apply on engine, proxy should recognise those objects on his creation(proxy get/set doesn't know about those attribute without it)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
