### PR TITLE
fix(FEC-8821): Safari doesn't show correctly youtube iframe

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
 .playkit-iOS .playkit-engine-youtube,
-.playkit-Mac-OS.playkit-touch .playkit-engine-youtube{
+.playkit-Mac-OS.playkit-Safari .playkit-engine-youtube{
   object-fit: fill;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,4 @@
-.playkit-iOS .playkit-engine-youtube {
+.playkit-iOS .playkit-engine-youtube,
+.playkit-Mac-OS.playkit-touch .playkit-engine-youtube{
   object-fit: fill;
 }

--- a/src/style.css
+++ b/src/style.css
@@ -1,4 +1,4 @@
 .playkit-iOS .playkit-engine-youtube,
-.playkit-Mac-OS.playkit-Safari .playkit-engine-youtube{
+.playkit-Mac-OS .playkit-engine-youtube{
   object-fit: fill;
 }


### PR DESCRIPTION
### Description of the Changes

add IOS change of object-fit for all Safari with Apple devices cause all of them aren't in the correct place

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment 
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
