### PR TITLE
build: fix release notes downgrade from 3.1.5 to 3.1.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,8 +34,8 @@ jobs:
       name: "Releasing a new version"
       if: tag IS present
       env: TRAVIS_MODE=release
-      before_deploy:
-        - conventional-github-releaser -t "$GH_TOKEN"
+      script:
+        - conventional-github-releaser -p angular -t $GH_NOTE_TOKEN
       deploy:
         - provider: releases
           api_key: $GH_TOKEN

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ jobs:
       if: tag IS present
       env: TRAVIS_MODE=release
       script:
-        - conventional-github-releaser -p angular -t $GH_NOTE_TOKEN
+        - conventional-github-releaser -p angular -t $GH_TOKEN
       deploy:
         - provider: releases
           api_key: $GH_TOKEN

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "babel-loader": "^8.1.0",
     "babel-plugin-istanbul": "^6.0.0",
     "chai": "^4.2.0",
-    "conventional-github-releaser": "^3.1.5",
+    "conventional-github-releaser": "3.1.3",
     "cross-env": "^7.0.2",
     "css-loader": "^4.2.0",
     "eslint": "^7.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2480,10 +2480,10 @@ conventional-commits-parser@^3.0.3, conventional-commits-parser@^3.1.0:
     through2 "^3.0.0"
     trim-off-newlines "^1.0.0"
 
-conventional-github-releaser@^3.1.5:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/conventional-github-releaser/-/conventional-github-releaser-3.1.5.tgz#d3dfe8b03c6dbfc5e84adce2c98cb87a78720ad3"
-  integrity sha512-VhPKbdN92b2ygnQLkuwHIfUaPAVrVfJVuQdxbmmVPkN927LDP98HthLWFVShh4pxqLK0nE66v78RERGJVeCzbg==
+conventional-github-releaser@3.1.3:
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/conventional-github-releaser/-/conventional-github-releaser-3.1.3.tgz#0074165abd0da675e56cfd08b3601de8faa4dcba"
+  integrity sha512-Yt2h9FrpMZV9geO38aXqCvd5N3YGnXZ07Du2kWjSWnBE+QIqcp+dAat/svvWfQyyKMiB1otcZidetPJoKRauqA==
   dependencies:
     conventional-changelog "^2.0.0"
     dateformat "^3.0.0"
@@ -2491,7 +2491,7 @@ conventional-github-releaser@^3.1.5:
     gh-got "^7.0.0"
     git-semver-tags "^2.0.0"
     lodash.merge "^4.0.2"
-    meow "^7.0.0"
+    meow "^5.0.0"
     object-assign "^4.0.1"
     q "^1.4.1"
     semver "^5.0.1"
@@ -5425,6 +5425,21 @@ meow@^4.0.0:
     read-pkg-up "^3.0.0"
     redent "^2.0.0"
     trim-newlines "^2.0.0"
+
+meow@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/meow/-/meow-5.0.0.tgz#dfc73d63a9afc714a5e371760eb5c88b91078aa4"
+  integrity sha512-CbTqYU17ABaLefO8vCU153ZZlprKYWDljcndKKDCFcYQITzWCXZAVk4QMFZPgvzrnUQ3uItnIE/LoUOwrT15Ig==
+  dependencies:
+    camelcase-keys "^4.0.0"
+    decamelize-keys "^1.0.0"
+    loud-rejection "^1.0.0"
+    minimist-options "^3.0.1"
+    normalize-package-data "^2.3.4"
+    read-pkg-up "^3.0.0"
+    redent "^2.0.0"
+    trim-newlines "^2.0.0"
+    yargs-parser "^10.0.0"
 
 meow@^7.0.0:
   version "7.0.1"
@@ -8483,6 +8498,13 @@ yargs-parser@13.1.2, yargs-parser@^13.1.2:
   dependencies:
     camelcase "^5.0.0"
     decamelize "^1.2.0"
+
+yargs-parser@^10.0.0:
+  version "10.1.0"
+  resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"
+  integrity sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==
+  dependencies:
+    camelcase "^4.1.0"
 
 yargs-parser@^15.0.1:
   version "15.0.1"


### PR DESCRIPTION
### Description of the Changes

Issue: conventional-github-releaser 3.1.5 doesn't work.
Solution: downgrade conventional-github-releaser to 3.1.3.

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated
