### PR TITLE
fix(SUP-36236): Youtube video are not played in a playlist

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -233,6 +233,9 @@ class Youtube extends FakeEventTarget implements IEngine {
   reset(): void {
     this._reset();
     this._eventManager.removeAll();
+    if (this._api) {
+      this._api.destroy && this._api.destroy();
+    }
   }
 
   /**


### PR DESCRIPTION
### Description of the Changes

**the isssue:**
on playlist mode, only first youtube entry is played, when moving to another youtube entry we have buffering and the video is not loaded.

**the solution:**
destroy the iframe api when moving between youtube entries

 solves [SUP-36236](https://kaltura.atlassian.net/browse/SUP-36236)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-36236]: https://kaltura.atlassian.net/browse/SUP-36236?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ