### PR TITLE
fix(SUP-40028): The playlist player freezes during the playback

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -1187,6 +1187,11 @@ class Youtube extends FakeEventTarget implements IEngine {
     this._playingIntervalId = null;
   }
 
+  // eslint-disable-next-line no-unused-vars
+  getThumbnail(time: number): null {
+    return null;
+  }
+
   resetAllCues(): void {}
   enterPictureInPicture(): void {}
   exitPictureInPicture(): void {}


### PR DESCRIPTION
### Description of the Changes

issue:
the playlist player freezes when moving to youtube entry (when timeline plugin is loaded).

solution:
youtube doesn't have getThumbnail function, added.

solves [SUP-40028](https://kaltura.atlassian.net/browse/SUP-40028)

### CheckLists

- [ ] changes have been done against master branch, and PR does not conflict
- [ ] new unit / functional tests have been added (whenever applicable)
- [ ] test are passing in local environment
- [ ] Travis tests are passing (or test results are not worse than on master branch :))
- [ ] Docs have been updated


[SUP-40028]: https://kaltura.atlassian.net/browse/SUP-40028?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ