### PR TITLE
fix(KMS-32100): Ensure every player using youtube plugin will start muted by default

### DIFF
--- a/src/youtube.js
+++ b/src/youtube.js
@@ -195,6 +195,8 @@ class Youtube extends FakeEventTarget implements IEngine {
     super();
     this._eventManager = new EventManager();
     this._createVideoElement();
+    this._muted = true; // Initialize as muted by default
+    this._forcedMuteOnInit = true; // Prevent unmuting during initialization
     this._init(source, config);
   }
 
@@ -227,6 +229,8 @@ class Youtube extends FakeEventTarget implements IEngine {
     this._isAdaptiveBitrate = true;
     this._playerTracks = [];
     this._currentState = null;
+    this._muted = true; // Reset to muted state
+    this._forcedMuteOnInit = true; // Reset initialization flag
     if (this._clipToInterval) {
       clearInterval(this._clipToInterval);
       this._clipToInterval = null;
@@ -658,6 +662,10 @@ class Youtube extends FakeEventTarget implements IEngine {
    */
   set muted(mute: boolean): void {
     if (this._playerReady()) {
+      // Prevent unmuting during initial load to enforce muted start
+      if (!mute && this._forcedMuteOnInit) {
+        return;
+      }
       mute ? this._api.mute() : this._api.unMute();
       this._muted = mute;
     }
@@ -683,7 +691,7 @@ class Youtube extends FakeEventTarget implements IEngine {
    * @public
    */
   get defaultMuted(): boolean {
-    return false;
+    return true;
   }
 
   /**
@@ -953,10 +961,13 @@ class Youtube extends FakeEventTarget implements IEngine {
     };
     this._sdkLoaded = new Promise((resolve, reject) => {
       this._apiReady = () => {
-        if (this._config.playback.muted || this._config.playback.autoplay) {
-          this._api.mute && this._api.mute();
-          this._muted = true;
-        }
+        // Always start muted for YouTube players
+        this._api.mute && this._api.mute();
+        this._muted = true;
+        // Allow unmuting after initial setup is complete
+        setTimeout(() => {
+          this._forcedMuteOnInit = false;
+        }, 100);
         resolve();
       };
       this._apiError = (e) => {

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -229,8 +229,8 @@ class Youtube extends FakeEventTarget implements IEngine {
     this._isAdaptiveBitrate = true;
     this._playerTracks = [];
     this._currentState = null;
-    this._muted = true; // Reset to muted state
-    this._forcedMuteOnInit = true; // Reset initialization flag
+    this._muted = true;
+    this._forcedMuteOnInit = true;
     if (this._clipToInterval) {
       clearInterval(this._clipToInterval);
       this._clipToInterval = null;
@@ -1036,10 +1036,6 @@ class Youtube extends FakeEventTarget implements IEngine {
           onVolumeChange: () =>
             this.dispatchEvent(new FakeEvent(EventType.VOLUME_CHANGE)),
         },
-        // Add iframe attributes to allow necessary permissions
-        attributes: {
-          allow: "autoplay; fullscreen; clipboard-write; encrypted-media; accelerometer; gyroscope; picture-in-picture; web-share"
-        }
       };
       config.playerVars.playsinline = this._config.playback.playsinline ? 1 : 0;
       config.playerVars.autoplay = this._config.playback.autoplay ? 1 : 0;

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -196,7 +196,6 @@ class Youtube extends FakeEventTarget implements IEngine {
     this._eventManager = new EventManager();
     this._createVideoElement();
     this._muted = true; // Initialize as muted by default
-    this._forcedMuteOnInit = true; // Prevent unmuting during initialization
     this._init(source, config);
   }
 
@@ -230,7 +229,6 @@ class Youtube extends FakeEventTarget implements IEngine {
     this._playerTracks = [];
     this._currentState = null;
     this._muted = true;
-    this._forcedMuteOnInit = true;
     if (this._clipToInterval) {
       clearInterval(this._clipToInterval);
       this._clipToInterval = null;
@@ -662,10 +660,6 @@ class Youtube extends FakeEventTarget implements IEngine {
    */
   set muted(mute: boolean): void {
     if (this._playerReady()) {
-      // Prevent unmuting during initial load to enforce muted start
-      if (!mute && this._forcedMuteOnInit) {
-        return;
-      }
       mute ? this._api.mute() : this._api.unMute();
       this._muted = mute;
     }
@@ -964,10 +958,6 @@ class Youtube extends FakeEventTarget implements IEngine {
         // Always start muted for YouTube players
         this._api.mute && this._api.mute();
         this._muted = true;
-        // Allow unmuting after initial setup is complete
-        setTimeout(() => {
-          this._forcedMuteOnInit = false;
-        }, 100);
         resolve();
       };
       this._apiError = (e) => {

--- a/src/youtube.js
+++ b/src/youtube.js
@@ -1025,6 +1025,10 @@ class Youtube extends FakeEventTarget implements IEngine {
           onVolumeChange: () =>
             this.dispatchEvent(new FakeEvent(EventType.VOLUME_CHANGE)),
         },
+        // Add iframe attributes to allow necessary permissions
+        attributes: {
+          allow: "autoplay; fullscreen; clipboard-write; encrypted-media; accelerometer; gyroscope; picture-in-picture; web-share"
+        }
       };
       config.playerVars.playsinline = this._config.playback.playsinline ? 1 : 0;
       config.playerVars.autoplay = this._config.playback.autoplay ? 1 : 0;


### PR DESCRIPTION
- Initializes YouTube player in a muted state by default.
- Updates muted setter to block unmuting until initialization completes.
- Changes `defaultMuted` getter to always return `true`.

Solves ticket [KMS-32100](https://kaltura.atlassian.net/browse/KMS-32100)

[KMS-32100]: https://kaltura.atlassian.net/browse/KMS-32100?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ